### PR TITLE
remove invalid profiling options from cabal file

### DIFF
--- a/cheapskate.cabal
+++ b/cheapskate.cabal
@@ -64,7 +64,6 @@ executable cheapskate
                      text >= 0.9 && < 1.3
   default-language:  Haskell2010
   ghc-options:       -Wall -fno-warn-unused-do-bind
-  ghc-prof-options:  -auto-exported -rtsopts
 
 executable cheapskate-dingus
   main-is:           cheapskate-dingus.hs
@@ -78,4 +77,3 @@ executable cheapskate-dingus
   else
     Buildable:       False
   ghc-options:       -Wall -fno-warn-unused-do-bind
-  ghc-prof-options:  -auto-exported -rtsopts


### PR DESCRIPTION
These flags specified in `cheapskate.cabal` are not valid GHC flags.

Rather than changing these to `-fprof-auto-exported` and `-fprof-rtsflags`, I have instead
removed them. Cabal's documentation, linked below, recommends that packages do not
choose their own profiling options, so that the person building the package can decide.

https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-ghc-prof-options